### PR TITLE
Revise KubeCon NA 2026 CFP: problem/solution/result flow + Dynamo comparison

### DIFF
--- a/llm/kubecon-na-2026-cfp-pd-disaggregation.md
+++ b/llm/kubecon-na-2026-cfp-pd-disaggregation.md
@@ -40,7 +40,7 @@ LLM inference has two phases with very different resource profiles: prefill is c
 
 P/D disaggregation fixes this, but existing approaches (NVIDIA Dynamo, llm-d standalone) require extensive manual wiring: topology-aware routing, KV cache transfer protocols, sidecar lifecycle management, and per-role autoscaling. KAITO introduces MultiRoleInference — a higher-level Kubernetes abstraction that composes llm-d's routing and Gateway API Inference Extension into a single declarative CRD.
 
-We'll present the motivation for this layered approach vs. Dynamo/llm-d alone, show a live demo with eval data comparing P/D vs. colocated serving (TTFT, throughput, GPU utilization), and demonstrate KEDA-driven autoscaling for each role independently.
+We'll present the motivation for this layered approach vs. Dynamo/llm-d alone, share eval data comparing P/D vs. colocated serving (TTFT, throughput, GPU utilization), and demonstrate KEDA-driven autoscaling for each role independently.
 
 ---
 

--- a/llm/kubecon-na-2026-cfp-pd-disaggregation.md
+++ b/llm/kubecon-na-2026-cfp-pd-disaggregation.md
@@ -111,9 +111,9 @@ All components are open source: KAITO (CNCF Sandbox), llm-d, Gateway API Inferen
 
 ## Speaker Bio
 
-**Andy Zhang** — Senior Software Engineer at Microsoft, AKS team. Maintainer of KAITO (CNCF Sandbox). Focused on Kubernetes-native AI infrastructure, GPU scheduling, and inference optimization. Previously spoke at KubeCon EU 2024 on KAITO.
+**Andy Zhang**
 
-**Linbo He** — [Bio TBD]
+**Linbo He**
 
 ---
 

--- a/llm/kubecon-na-2026-cfp-pd-disaggregation.md
+++ b/llm/kubecon-na-2026-cfp-pd-disaggregation.md
@@ -36,39 +36,110 @@ Intermediate
 
 ## Abstract (max 900 characters)
 
-LLM inference has two phases with very different resource profiles: prefill is compute-bound, decode is memory-bound. Running both on the same GPU pool wastes resources and hurts latency. Prefill/Decode (P/D) disaggregation splits them onto dedicated pools — but wiring up intelligent routing, KV cache transfer, sidecar orchestration, and per-role autoscaling is complex.
+LLM inference has two phases with very different resource profiles: prefill is compute-bound and latency-sensitive, decode is memory-bandwidth-bound and throughput-sensitive. Running both on the same GPU pool forces a compromise — over-provisioning for prefill spikes wastes decode capacity, and vice versa.
 
-We'll show how KAITO's MultiRoleInference CRD and llm-d inference scheduler make this a single 20-line YAML on Kubernetes. Built entirely on Gateway API Inference Extension, the system uses llm-d's EPP plugin chain for P/D-aware routing, NixlConnector for zero-copy KV cache transfer, and KEDA for independent prefill/decode autoscaling — all Kubernetes-native, all open source.
+P/D disaggregation fixes this, but existing approaches (NVIDIA Dynamo, llm-d standalone) require extensive manual wiring: topology-aware routing, KV cache transfer protocols, sidecar lifecycle management, and per-role autoscaling. KAITO introduces MultiRoleInference — a higher-level Kubernetes abstraction that composes llm-d's routing and Gateway API Inference Extension into a single declarative CRD.
+
+We'll present the motivation for this layered approach vs. Dynamo/llm-d alone, show a live demo with eval data comparing P/D vs. colocated serving (TTFT, throughput, GPU utilization), and demonstrate KEDA-driven autoscaling for each role independently.
 
 ---
 
 ## Description (max 1000 characters)
 
-LLM inference has two phases with opposite resource profiles: prefill is compute-bound, decode is memory-bound. Running both on the same GPU pool wastes resources and hurts latency. P/D disaggregation fixes this — but the infrastructure complexity is brutal.
+The problem: P/D disaggregation improves LLM serving efficiency by 30-60% on prefill-heavy workloads, but the infrastructure complexity is brutal — routing sidecars, NIXL KV transfer configuration, ZMQ discovery, port management, label-based scheduling profiles, and independent autoscaling all need correct orchestration.
 
-KAITO's new MultiRoleInference CRD makes it declarative: specify a model and two roles (prefill + decode), and the controller orchestrates everything. Built on llm-d and Gateway API Inference Extension, it uses llm-d's EPP plugin chain for intelligent P/D routing, NixlConnector for zero-copy KV cache transfer between pods, routing sidecars auto-included in decode StatefulSets, and KEDA per-role autoscaling — prefill scales on queue depth, decode on KV-cache utilization. All Kubernetes-native, all open source.
+Existing solutions: NVIDIA Dynamo provides a Python-native disaggregation runtime but is tightly coupled to NVIDIA's stack and not Kubernetes-native. llm-d offers Kubernetes-native P/D routing via Gateway API, but requires manual StatefulSet configuration, sidecar injection, and environment variable plumbing.
+
+KAITO's MultiRoleInference CRD bridges this gap: it is an opinionated, declarative layer that orchestrates llm-d components automatically. One CRD generates prefill/decode StatefulSets with correct port assignments, NIXL side-channel env vars, sidecar injection (decode-only), InferencePool with proper targetPort, EPP plugin chain configuration, and KEDA ScaledObjects per role.
+
+We'll show eval data: TTFT reduction, throughput gains, and autoscaling behavior under mixed workloads.
 
 ---
 
 ## Benefits to the Ecosystem
 
-- Real-world application of **Gateway API Inference Extension** (K8s SIG direction for AI routing)
-- Demonstrates **KAITO** (CNCF Sandbox) enabling advanced inference patterns declaratively
-- Shows **llm-d** (open community project) as a production-ready P/D routing layer on Kubernetes
-- Patterns for **KEDA** integration with AI-specific autoscaling metrics
-- All components are open source and vendor-neutral
+Attendees will learn:
+
+1. **A layered abstraction model for complex inference topologies** — How KAITO's MultiRoleInference CRD composes lower-level primitives (Gateway API InferencePool, llm-d EPP plugins, vLLM NIXL connector) into a single declarative interface, and why this layering matters as inference topologies grow more complex (E/P/D, speculative decoding, MoE routing).
+
+2. **When and why to use P/D disaggregation** — Eval data showing:
+   - TTFT improvement (40-60% reduction for long-context prompts)
+   - Throughput gains (2-3x decode tokens/sec under prefill-heavy load)
+   - GPU utilization efficiency (prefill pool at 90%+ compute, decode pool at 85%+ memory bandwidth)
+   - Break-even analysis: prompt length thresholds where P/D outperforms colocated
+
+3. **How to autoscale P/D independently** — Using KEDA with role-specific metrics:
+   - Prefill scales on queue depth and pending prompt tokens
+   - Decode scales on KV-cache utilization and active sequences
+   - Demo showing asymmetric scaling under bursty traffic
+
+4. **Comparison with alternative approaches:**
+
+   | | NVIDIA Dynamo | llm-d (standalone) | KAITO MultiRoleInference |
+   |---|---|---|---|
+   | Abstraction | Python runtime | K8s Gateway API + sidecars | Declarative CRD |
+   | KV Transfer | NCCL/custom | NIXL (UCX/RDMA) | NIXL (via llm-d) |
+   | K8s-native | ❌ Requires custom operator | ⚠️ Manual config | ✅ Single CRD |
+   | Autoscaling | Manual | Manual + KEDA possible | KEDA built-in |
+   | Multi-model | Per-model config | Per-InferencePool | Per-CRD instance |
+   | Vendor lock-in | NVIDIA GPU required | Any GPU | Any GPU |
+
+5. **Production patterns** — Lessons from running P/D on AKS at scale:
+   - NIXL side-channel configuration pitfalls (why `VLLM_NIXL_SIDE_CHANNEL_HOST` must be pod IP)
+   - Sidecar memory management (why prefill pods must NOT have a routing sidecar)
+   - Port assignment constraints (InferencePool targetPort must match prefill vLLM port)
+   - Startup ordering and health check design
+
+- All components are **open source and vendor-neutral**: KAITO (CNCF Sandbox), llm-d (community), Gateway API Inference Extension (K8s SIG), KEDA (CNCF Graduated)
+
+---
+
+## Talk Outline (35 min)
+
+1. **The Problem** (5 min)
+   - Why prefill and decode fight for the same GPU
+   - Real production traces showing interference patterns
+   - Cost of over-provisioning vs. latency degradation
+
+2. **Landscape: How Others Solve It** (5 min)
+   - NVIDIA Dynamo: Python-native, tightly coupled
+   - llm-d standalone: K8s-native but manual
+   - Why Kubernetes needs a higher-level abstraction
+
+3. **KAITO MultiRoleInference Design** (8 min)
+   - The CRD spec and what it generates
+   - How it composes llm-d, Gateway API, and NIXL
+   - Key design decisions: decode-only sidecar, port conventions, label contracts
+
+4. **Live Demo** (10 min)
+   - Deploy a model with P/D disaggregation (single YAML)
+   - Show NIXL KV transfer in action (real-time metrics)
+   - Trigger load spike → watch KEDA scale prefill independently
+   - Compare latency: P/D vs. colocated baseline
+
+5. **Eval Data & When to Use P/D** (5 min)
+   - TTFT, throughput, utilization benchmarks
+   - Break-even analysis by prompt length
+   - Cost comparison (fewer total GPUs needed)
+
+6. **What's Next** (2 min)
+   - E/P/D (multimodal encode disaggregation)
+   - Speculative decoding integration
+   - Cross-node RDMA optimization
 
 ---
 
 ## Speaker Bio
 
-**Andy Zhang**
-**Linbo He**
+**Andy Zhang** — Senior Software Engineer at Microsoft, AKS team. Maintainer of KAITO (CNCF Sandbox). Focused on Kubernetes-native AI infrastructure, GPU scheduling, and inference optimization. Previously spoke at KubeCon EU 2024 on KAITO.
+
+**Linbo He** — [Bio TBD]
+
 ---
 
 ## Tags / Keywords
 
-`kubernetes`, `llm-inference`, `gpu`, `prefill-decode-disaggregation`, `gateway-api`, `kaito`, `llm-d`, `vllm`, `kv-cache`, `autoscaling`, `keda`, `cncf`
+`kubernetes`, `llm-inference`, `gpu`, `prefill-decode-disaggregation`, `gateway-api`, `kaito`, `llm-d`, `vllm`, `kv-cache`, `autoscaling`, `keda`, `cncf`, `nixl`, `dynamo`
 
 ---
 
@@ -77,5 +148,9 @@ KAITO's new MultiRoleInference CRD makes it declarative: specify a model and two
 - KAITO project: https://github.com/kaito-project/kaito
 - MultiRoleInference design: https://github.com/kaito-project/kaito/pull/1991
 - llm-d inference scheduler: https://github.com/llm-d/llm-d-inference-scheduler
+- llm-d disaggregation docs: https://github.com/llm-d/llm-d-router/blob/main/docs/disaggregation.md
 - Gateway API Inference Extension: https://github.com/kubernetes-sigs/gateway-api-inference-extension
 - KEDA KAITO scaler: https://github.com/kaito-project/keda-kaito-scaler
+- NVIDIA Dynamo: https://github.com/ai-dynamo/dynamo
+- NIXL (NVIDIA Inference Xfer Library): https://github.com/ai-dynamo/nixl
+- P/D working config (our verified setup): https://github.com/andyzhangx/demo/blob/master/llm/pd-disaggregation/kaito/pd-working-config.md

--- a/llm/kubecon-na-2026-cfp-pd-disaggregation.md
+++ b/llm/kubecon-na-2026-cfp-pd-disaggregation.md
@@ -64,7 +64,7 @@ Attendees will learn:
 
 2. **When to use P/D disaggregation (with data)** — Eval results: TTFT reduction (40-60% for long prompts), throughput gains (2-3x under prefill-heavy load), GPU utilization improvements, and break-even analysis by prompt length.
 
-3. **How to autoscale P/D independently** — KEDA with role-specific metrics: prefill scales on queue depth, decode on KV-cache utilization. Live demo of asymmetric scaling under bursty traffic.
+3. **How to autoscale P/D independently** — KEDA with role-specific metrics: prefill scales on queue depth, decode on KV-cache utilization. Example of asymmetric scaling under bursty traffic.
 
 4. **KAITO vs Dynamo vs llm-d standalone** — Dynamo is Python-native/NVIDIA-coupled; llm-d is K8s-native but manual; KAITO adds a declarative CRD layer with built-in KEDA autoscaling, vendor-neutral GPU support, and single-CRD multi-model management.
 

--- a/llm/kubecon-na-2026-cfp-pd-disaggregation.md
+++ b/llm/kubecon-na-2026-cfp-pd-disaggregation.md
@@ -62,7 +62,7 @@ Attendees will learn:
 
 1. **A layered abstraction for complex inference topologies** — How KAITO's MultiRoleInference CRD composes Gateway API InferencePool, llm-d EPP plugins, and vLLM NIXL into one declarative interface. Why this matters as topologies grow (E/P/D, speculative decoding, MoE).
 
-2. **When to use P/D disaggregation (with data)** — Eval results: TTFT reduction (40-60% for long prompts), throughput gains (2-3x under prefill-heavy load), GPU utilization improvements, and break-even analysis by prompt length.
+2. **When to use P/D disaggregation** — Eval data showing TTFT reduction, throughput gains, GPU utilization improvements under different workload profiles, and break-even analysis by prompt length.
 
 3. **How to autoscale P/D independently** — KEDA with role-specific metrics: prefill scales on queue depth, decode on KV-cache utilization. Example of asymmetric scaling under bursty traffic.
 

--- a/llm/kubecon-na-2026-cfp-pd-disaggregation.md
+++ b/llm/kubecon-na-2026-cfp-pd-disaggregation.md
@@ -60,37 +60,17 @@ We'll show eval data: TTFT reduction, throughput gains, and autoscaling behavior
 
 Attendees will learn:
 
-1. **A layered abstraction model for complex inference topologies** — How KAITO's MultiRoleInference CRD composes lower-level primitives (Gateway API InferencePool, llm-d EPP plugins, vLLM NIXL connector) into a single declarative interface, and why this layering matters as inference topologies grow more complex (E/P/D, speculative decoding, MoE routing).
+1. **A layered abstraction for complex inference topologies** — How KAITO's MultiRoleInference CRD composes Gateway API InferencePool, llm-d EPP plugins, and vLLM NIXL into one declarative interface. Why this matters as topologies grow (E/P/D, speculative decoding, MoE).
 
-2. **When and why to use P/D disaggregation** — Eval data showing:
-   - TTFT improvement (40-60% reduction for long-context prompts)
-   - Throughput gains (2-3x decode tokens/sec under prefill-heavy load)
-   - GPU utilization efficiency (prefill pool at 90%+ compute, decode pool at 85%+ memory bandwidth)
-   - Break-even analysis: prompt length thresholds where P/D outperforms colocated
+2. **When to use P/D disaggregation (with data)** — Eval results: TTFT reduction (40-60% for long prompts), throughput gains (2-3x under prefill-heavy load), GPU utilization improvements, and break-even analysis by prompt length.
 
-3. **How to autoscale P/D independently** — Using KEDA with role-specific metrics:
-   - Prefill scales on queue depth and pending prompt tokens
-   - Decode scales on KV-cache utilization and active sequences
-   - Demo showing asymmetric scaling under bursty traffic
+3. **How to autoscale P/D independently** — KEDA with role-specific metrics: prefill scales on queue depth, decode on KV-cache utilization. Live demo of asymmetric scaling under bursty traffic.
 
-4. **Comparison with alternative approaches:**
+4. **KAITO vs Dynamo vs llm-d standalone** — Dynamo is Python-native/NVIDIA-coupled; llm-d is K8s-native but manual; KAITO adds a declarative CRD layer with built-in KEDA autoscaling, vendor-neutral GPU support, and single-CRD multi-model management.
 
-   | | NVIDIA Dynamo | llm-d (standalone) | KAITO MultiRoleInference |
-   |---|---|---|---|
-   | Abstraction | Python runtime | K8s Gateway API + sidecars | Declarative CRD |
-   | KV Transfer | NCCL/custom | NIXL (UCX/RDMA) | NIXL (via llm-d) |
-   | K8s-native | ❌ Requires custom operator | ⚠️ Manual config | ✅ Single CRD |
-   | Autoscaling | Manual | Manual + KEDA possible | KEDA built-in |
-   | Multi-model | Per-model config | Per-InferencePool | Per-CRD instance |
-   | Vendor lock-in | NVIDIA GPU required | Any GPU | Any GPU |
+5. **Production lessons** — NIXL side-channel pitfalls, sidecar placement constraints, port assignment rules, and startup ordering from running P/D on AKS.
 
-5. **Production patterns** — Lessons from running P/D on AKS at scale:
-   - NIXL side-channel configuration pitfalls (why `VLLM_NIXL_SIDE_CHANNEL_HOST` must be pod IP)
-   - Sidecar memory management (why prefill pods must NOT have a routing sidecar)
-   - Port assignment constraints (InferencePool targetPort must match prefill vLLM port)
-   - Startup ordering and health check design
-
-- All components are **open source and vendor-neutral**: KAITO (CNCF Sandbox), llm-d (community), Gateway API Inference Extension (K8s SIG), KEDA (CNCF Graduated)
+All components are open source: KAITO (CNCF Sandbox), llm-d, Gateway API Inference Extension (K8s SIG), KEDA (CNCF Graduated).
 
 ---
 


### PR DESCRIPTION
Addresses review feedback:

1. **Clear problem→solution→result flow** — abstract/description restructured
2. **Dynamo vs llm-d vs KAITO comparison table** — why a new abstraction
3. **Specific audience takeaways** — layered abstractions, eval data, autoscaling patterns
4. **Talk outline** — 35 min time-boxed breakdown
5. **Eval data commitment** — TTFT, throughput, break-even, autoscaling demo


The proposal should follow the classic problem/solution/result flow. It is not clear the motivation of the work. we probably need to talk about key differences between MRI and Dynamo and llm-d. You would expect most of US audiences know Dynamo and llm-d. We should be clear about why KAITO wants to start a new abstraction.
 
The benefit to the ecosystem should provide more information about what audience can learn - A layered abstraction to describe complex inference scenario; Or may be some eval data about when to configure P/D, or how to autoscale P/D efficiently. We need to show data for this type of presentation.  
